### PR TITLE
341 loeschen von vertraegen an etw

### DIFF
--- a/plugins/org.polymap.kaps/src/org/polymap/kaps/model/KapsRepository.java
+++ b/plugins/org.polymap.kaps/src/org/polymap/kaps/model/KapsRepository.java
@@ -540,28 +540,7 @@ public class KapsRepository
     		wohnung.kaufpreis().set(null);
     		wohnung.bereinigterVollpreis().set(null);
     		wohnung.vollpreisWohnflaeche().set(null);
-    		// editierbar in Wohnungsformular
-    		wohnung.abschlagGarage().set(null);
-    		wohnung.abschlagStellplatz().set(null);
-    		wohnung.abschlagAnderes().set(null);
-    		
-    		wohnung.schaetzungGarage().set(null);
-    		wohnung.schaetzungStellplatz().set(null);
-    		wohnung.schaetzungAnderes().set(null);
-    		
-    		wohnung.gebaeudeArtGarage().set(null);
-    		wohnung.gebaeudeArtStellplatz().set(null);
-    		wohnung.gebaeudeArtAnderes().set(null);
-    		
-    		wohnung.anzahlGaragen().set(null);
-    		wohnung.anzahlStellplatz().set(null);
-    		wohnung.anzahlAnderes().set(null);
-    		
-    		wohnung.vermietet().set("unbekannt");
-    		wohnung.zurAuswertungGeeignet().set(null);
-    		
-    		wohnung.gewichtung().set(null);
-    		wohnung.bemerkungVertragsdaten().set(null);
+    		wohnung.bodenpreis().set(null);
     	}
     	
         ErmittlungModernisierungsgradComposite ermittlungModernisierungsgradComposite = ErmittlungModernisierungsgradComposite.Mixin

--- a/plugins/org.polymap.kaps/src/org/polymap/kaps/model/KapsRepository.java
+++ b/plugins/org.polymap.kaps/src/org/polymap/kaps/model/KapsRepository.java
@@ -535,6 +535,17 @@ public class KapsRepository
 
 
     private void remove( VertragComposite vertrag ) {
+    	for (WohnungComposite wohnung : WohnungComposite.Mixin.findWohnungenFor( vertrag )) {
+    		// nicht editierbar in Wohnungsformular
+    		wohnung.kaufpreis().set(0d);
+    		wohnung.bereinigterVollpreis().set(0d);
+    		wohnung.vollpreisWohnflaeche().set(0d);
+    		// editierbar in Wohnungsformular
+    		wohnung.abschlagGarage().set(0d);
+    		wohnung.abschlagStellplatz().set(0d);
+    		wohnung.abschlagAnderes().set(0d);
+    	}
+    	
         ErmittlungModernisierungsgradComposite ermittlungModernisierungsgradComposite = ErmittlungModernisierungsgradComposite.Mixin
                 .forVertrag( vertrag );
         if (ermittlungModernisierungsgradComposite != null) {

--- a/plugins/org.polymap.kaps/src/org/polymap/kaps/model/KapsRepository.java
+++ b/plugins/org.polymap.kaps/src/org/polymap/kaps/model/KapsRepository.java
@@ -537,13 +537,31 @@ public class KapsRepository
     private void remove( VertragComposite vertrag ) {
     	for (WohnungComposite wohnung : WohnungComposite.Mixin.findWohnungenFor( vertrag )) {
     		// nicht editierbar in Wohnungsformular
-    		wohnung.kaufpreis().set(0d);
-    		wohnung.bereinigterVollpreis().set(0d);
-    		wohnung.vollpreisWohnflaeche().set(0d);
+    		wohnung.kaufpreis().set(null);
+    		wohnung.bereinigterVollpreis().set(null);
+    		wohnung.vollpreisWohnflaeche().set(null);
     		// editierbar in Wohnungsformular
-    		wohnung.abschlagGarage().set(0d);
-    		wohnung.abschlagStellplatz().set(0d);
-    		wohnung.abschlagAnderes().set(0d);
+    		wohnung.abschlagGarage().set(null);
+    		wohnung.abschlagStellplatz().set(null);
+    		wohnung.abschlagAnderes().set(null);
+    		
+    		wohnung.schaetzungGarage().set(null);
+    		wohnung.schaetzungStellplatz().set(null);
+    		wohnung.schaetzungAnderes().set(null);
+    		
+    		wohnung.gebaeudeArtGarage().set(null);
+    		wohnung.gebaeudeArtStellplatz().set(null);
+    		wohnung.gebaeudeArtAnderes().set(null);
+    		
+    		wohnung.anzahlGaragen().set(null);
+    		wohnung.anzahlStellplatz().set(null);
+    		wohnung.anzahlAnderes().set(null);
+    		
+    		wohnung.vermietet().set("unbekannt");
+    		wohnung.zurAuswertungGeeignet().set(null);
+    		
+    		wohnung.gewichtung().set(null);
+    		wohnung.bemerkungVertragsdaten().set(null);
     	}
     	
         ErmittlungModernisierungsgradComposite ermittlungModernisierungsgradComposite = ErmittlungModernisierungsgradComposite.Mixin

--- a/plugins/org.polymap.kaps/src/org/polymap/kaps/ui/form/WohnungVertragsdatenFormEditorPage.java
+++ b/plugins/org.polymap.kaps/src/org/polymap/kaps/ui/form/WohnungVertragsdatenFormEditorPage.java
@@ -197,25 +197,10 @@ public class WohnungVertragsdatenFormEditorPage
         }
         
         if(keinVertragZugeordnet) {
-        	wohnung.kaufpreis().set(0d);
-        	wohnung.vollpreisWohnflaeche().set(0d);
-        	wohnung.bereinigterVollpreis().set(0d);
-    		wohnung.abschlagGarage().set(null);
-    		wohnung.abschlagStellplatz().set(null);
-    		wohnung.abschlagAnderes().set(null);
-    		wohnung.schaetzungGarage().set(null);
-    		wohnung.schaetzungStellplatz().set(null);
-    		wohnung.schaetzungAnderes().set(null);
-    		wohnung.gebaeudeArtGarage().set(null);
-    		wohnung.gebaeudeArtStellplatz().set(null);
-    		wohnung.gebaeudeArtAnderes().set(null);
-    		wohnung.anzahlGaragen().set(null);
-    		wohnung.anzahlStellplatz().set(null);
-    		wohnung.anzahlAnderes().set(null);
-    		wohnung.vermietet().set("unbekannt");
-    		wohnung.zurAuswertungGeeignet().set(null);
-    		wohnung.gewichtung().set(null);
-    		wohnung.bemerkungVertragsdaten().set(null);
+        	wohnung.kaufpreis().set(null);
+    		wohnung.bereinigterVollpreis().set(null);
+    		wohnung.vollpreisWohnflaeche().set(null);
+    		wohnung.bodenpreis().set(null);
         }
 
         lastLine = newLine;

--- a/plugins/org.polymap.kaps/src/org/polymap/kaps/ui/form/WohnungVertragsdatenFormEditorPage.java
+++ b/plugins/org.polymap.kaps/src/org/polymap/kaps/ui/form/WohnungVertragsdatenFormEditorPage.java
@@ -112,7 +112,8 @@ public class WohnungVertragsdatenFormEditorPage
 
         final VertragComposite vertrag = wohnung.flurstueck().get() != null ? wohnung.flurstueck().get().vertrag()
                 .get() : null;
-        String label = vertrag == null ? "Kein Vertrag zugewiesen" : "Vertrag "
+        final boolean keinVertragZugeordnet = vertrag == null;         
+        String label = keinVertragZugeordnet ? "Kein Vertrag zugewiesen" : "Vertrag "
                 + EingangsNummerFormatter.format( vertrag.eingangsNr().get() ) + " öffnen";
         final ActionButton openErweiterteDaten = new ActionButton( parent, new Action( label ) {
 
@@ -197,7 +198,7 @@ public class WohnungVertragsdatenFormEditorPage
 
         lastLine = newLine;
         newLine = createLabel( parent, "Vollpreis", left().right( ONE ).top( lastLine ), SWT.RIGHT );
-        createPreisField( wohnung.kaufpreis(), left().left( ONE ).right( TWO ).top( lastLine ), parent, false );
+        createPreisField( wohnung.kaufpreis(), left().left( ONE ).right( TWO ).top( lastLine ), parent, keinVertragZugeordnet );
 
         lastLine = newLine;
         newLine = createLabel( parent, "Abschlag in €", left().right( TWO ).top( lastLine, 22 ), SWT.CENTER );
@@ -258,7 +259,7 @@ public class WohnungVertragsdatenFormEditorPage
         lastLine = newLine;
         newLine = createLabel( parent, "bereinigter Vollpreis", left().right( ONE ).top( lastLine, 12 ), SWT.RIGHT );
         createPreisField( wohnung.bereinigterVollpreis(), left().left( ONE ).right( TWO ).top( lastLine ), parent,
-                false );
+        		keinVertragZugeordnet );
         site.addFieldListener( vollpreis = new FieldCalculation( pageSite, 2, wohnung.bereinigterVollpreis(), wohnung
                 .kaufpreis(), wohnung.abschlagGarage(), wohnung.abschlagStellplatz(), wohnung.abschlagAnderes() ) {
 
@@ -286,7 +287,7 @@ public class WohnungVertragsdatenFormEditorPage
         lastLine = newLine;
         newLine = createLabel( parent, "Vollpreis Wohnfläche", left().right( ONE ).top( lastLine ), SWT.RIGHT );
         createPreisField( wohnung.vollpreisWohnflaeche(), left().left( ONE ).right( TWO ).top( lastLine ), parent,
-                false );
+        		keinVertragZugeordnet );
         site.addFieldListener( vollpreisWohnflaeche = new FieldCalculation( pageSite, 2,
                 wohnung.vollpreisWohnflaeche(), wohnung.bereinigterVollpreis(), wohnung.wohnflaeche() ) {
 

--- a/plugins/org.polymap.kaps/src/org/polymap/kaps/ui/form/WohnungVertragsdatenFormEditorPage.java
+++ b/plugins/org.polymap.kaps/src/org/polymap/kaps/ui/form/WohnungVertragsdatenFormEditorPage.java
@@ -195,12 +195,31 @@ public class WohnungVertragsdatenFormEditorPage
             delete.setEnabled( true );
             newLine = delete;
         }
+        
+        if(keinVertragZugeordnet) {
+        	wohnung.kaufpreis().set(0d);
+        	wohnung.vollpreisWohnflaeche().set(0d);
+        	wohnung.bereinigterVollpreis().set(0d);
+    		wohnung.abschlagGarage().set(null);
+    		wohnung.abschlagStellplatz().set(null);
+    		wohnung.abschlagAnderes().set(null);
+    		wohnung.schaetzungGarage().set(null);
+    		wohnung.schaetzungStellplatz().set(null);
+    		wohnung.schaetzungAnderes().set(null);
+    		wohnung.gebaeudeArtGarage().set(null);
+    		wohnung.gebaeudeArtStellplatz().set(null);
+    		wohnung.gebaeudeArtAnderes().set(null);
+    		wohnung.anzahlGaragen().set(null);
+    		wohnung.anzahlStellplatz().set(null);
+    		wohnung.anzahlAnderes().set(null);
+    		wohnung.vermietet().set("unbekannt");
+    		wohnung.zurAuswertungGeeignet().set(null);
+    		wohnung.gewichtung().set(null);
+    		wohnung.bemerkungVertragsdaten().set(null);
+        }
 
         lastLine = newLine;
         newLine = createLabel( parent, "Vollpreis", left().right( ONE ).top( lastLine ), SWT.RIGHT );
-        if(keinVertragZugeordnet) {
-        	wohnung.kaufpreis().set(0d);
-        }
         createPreisField( wohnung.kaufpreis(), left().left( ONE ).right( TWO ).top( lastLine ), parent, false );
 
         lastLine = newLine;
@@ -261,9 +280,6 @@ public class WohnungVertragsdatenFormEditorPage
 
         lastLine = newLine;
         newLine = createLabel( parent, "bereinigter Vollpreis", left().right( ONE ).top( lastLine, 12 ), SWT.RIGHT );
-        if(keinVertragZugeordnet) {
-        	wohnung.bereinigterVollpreis().set(0d);
-        }
         createPreisField( wohnung.bereinigterVollpreis(), left().left( ONE ).right( TWO ).top( lastLine ), parent,
         		false );
         site.addFieldListener( vollpreis = new FieldCalculation( pageSite, 2, wohnung.bereinigterVollpreis(), wohnung
@@ -292,9 +308,6 @@ public class WohnungVertragsdatenFormEditorPage
 
         lastLine = newLine;
         newLine = createLabel( parent, "Vollpreis Wohnfläche", left().right( ONE ).top( lastLine ), SWT.RIGHT );
-        if(keinVertragZugeordnet) {
-        	wohnung.vollpreisWohnflaeche().set(0d);
-        }
         createPreisField( wohnung.vollpreisWohnflaeche(), left().left( ONE ).right( TWO ).top( lastLine ), parent,
         		false );
         site.addFieldListener( vollpreisWohnflaeche = new FieldCalculation( pageSite, 2,

--- a/plugins/org.polymap.kaps/src/org/polymap/kaps/ui/form/WohnungVertragsdatenFormEditorPage.java
+++ b/plugins/org.polymap.kaps/src/org/polymap/kaps/ui/form/WohnungVertragsdatenFormEditorPage.java
@@ -198,7 +198,10 @@ public class WohnungVertragsdatenFormEditorPage
 
         lastLine = newLine;
         newLine = createLabel( parent, "Vollpreis", left().right( ONE ).top( lastLine ), SWT.RIGHT );
-        createPreisField( wohnung.kaufpreis(), left().left( ONE ).right( TWO ).top( lastLine ), parent, keinVertragZugeordnet );
+        if(keinVertragZugeordnet) {
+        	wohnung.kaufpreis().set(0d);
+        }
+        createPreisField( wohnung.kaufpreis(), left().left( ONE ).right( TWO ).top( lastLine ), parent, false );
 
         lastLine = newLine;
         newLine = createLabel( parent, "Abschlag in €", left().right( TWO ).top( lastLine, 22 ), SWT.CENTER );
@@ -258,8 +261,11 @@ public class WohnungVertragsdatenFormEditorPage
 
         lastLine = newLine;
         newLine = createLabel( parent, "bereinigter Vollpreis", left().right( ONE ).top( lastLine, 12 ), SWT.RIGHT );
+        if(keinVertragZugeordnet) {
+        	wohnung.bereinigterVollpreis().set(0d);
+        }
         createPreisField( wohnung.bereinigterVollpreis(), left().left( ONE ).right( TWO ).top( lastLine ), parent,
-        		keinVertragZugeordnet );
+        		false );
         site.addFieldListener( vollpreis = new FieldCalculation( pageSite, 2, wohnung.bereinigterVollpreis(), wohnung
                 .kaufpreis(), wohnung.abschlagGarage(), wohnung.abschlagStellplatz(), wohnung.abschlagAnderes() ) {
 
@@ -286,8 +292,11 @@ public class WohnungVertragsdatenFormEditorPage
 
         lastLine = newLine;
         newLine = createLabel( parent, "Vollpreis Wohnfläche", left().right( ONE ).top( lastLine ), SWT.RIGHT );
+        if(keinVertragZugeordnet) {
+        	wohnung.vollpreisWohnflaeche().set(0d);
+        }
         createPreisField( wohnung.vollpreisWohnflaeche(), left().left( ONE ).right( TWO ).top( lastLine ), parent,
-        		keinVertragZugeordnet );
+        		false );
         site.addFieldListener( vollpreisWohnflaeche = new FieldCalculation( pageSite, 2,
                 wohnung.vollpreisWohnflaeche(), wohnung.bereinigterVollpreis(), wohnung.wohnflaeche() ) {
 


### PR DESCRIPTION
Alle vertragsbezogenen Daten an einer Wohnung werden resettet beim
- Löschen eines Vertrags
- Öffnen der Vertragsdaten-Tab an einer Wohnung, wenn dieser Wohnung kein Vertrag mehr zugeordnet ist
