### PR TITLE
368: Fehlermeldung bei Meldung STALA

### DIFF
--- a/plugins/org.polymap.kaps/src/org/polymap/kaps/exporter/VertragStaLaAgrarExporter.java
+++ b/plugins/org.polymap.kaps/src/org/polymap/kaps/exporter/VertragStaLaAgrarExporter.java
@@ -395,23 +395,23 @@ public class VertragStaLaAgrarExporter
 
         // String hypotheken =
         Double h = vdc.hypothekStala().get();
-        if (h == null) {
-            errors.add( error( vertrag, "Hypotheken nicht gefunden, nutze 0" ) );
-        }
+//        if (h == null) {
+//            errors.add( error( vertrag, "Hypotheken nicht gefunden, nutze 0" ) );
+//        }
         contents.add( String.format( "%08d", h != null ? h.intValue() : 0 ) );
 
         // String tauschgrundstück =
         h = vdc.wertTauschStala().get();
-        if (h == null) {
-            errors.add( error( vertrag, "Wert des Tauschgrundstückes nicht gefunden, nutze 0" ) );
-        }
+//        if (h == null) {
+//            errors.add( error( vertrag, "Wert des Tauschgrundstückes nicht gefunden, nutze 0" ) );
+//        }
         contents.add( String.format( "%08d", h != null ? h.intValue() : 0 ) );
 
         // String sonstiges =
         h = vdc.wertSonstigesStala().get();
-        if (h == null) {
-            errors.add( error( vertrag, "Wert sonstige Leistungen nicht gefunden, nutze 0" ) );
-        }
+//        if (h == null) {
+//            errors.add( error( vertrag, "Wert sonstige Leistungen nicht gefunden, nutze 0" ) );
+//        }
         contents.add( String.format( "%08d", h != null ? h.intValue() : 0 ) );
 
         String b = vdc.bemerkungStala().get();


### PR DESCRIPTION
Task-Url: http://polymap.org/kaps/ticket/368

Fehlermeldungen für fehlende Werte für Hypothek, Tauschgrundstück und
sonstige Leistungen entfernt
