### PR TITLE
#280 - Beim initialen Laden muss, auch wenn newValue null ist, auf da…

### DIFF
--- a/plugins/org.polymap.kaps/src/org/polymap/kaps/ui/form/KaufvertragFlurstueckeFormEditorPage.java
+++ b/plugins/org.polymap.kaps/src/org/polymap/kaps/ui/form/KaufvertragFlurstueckeFormEditorPage.java
@@ -485,8 +485,7 @@ public class KaufvertragFlurstueckeFormEditorPage
 
             @Override
             public void fieldChange( FormFieldEvent ev ) {
-                if (ev.getEventCode() == VALUE_CHANGE && ev.getFieldName().equalsIgnoreCase( prefix + "gemarkung" ) 
-                		&& selectedGemarkung != ev.getNewValue() && ev.getNewValue() != null) {
+                if (ev.getEventCode() == VALUE_CHANGE && ev.getFieldName().equalsIgnoreCase( prefix + "gemarkung" )) {
                     // log.info( "gemarkungListener: " + ev);
                     // if ((ev.getNewValue() == null && selectedGemarkung != null)
                     // || (ev.getNewValue() != null && !ev.getNewValue().equals(


### PR DESCRIPTION
…s Event reagiert werden, sonst sind die Komboboxen leer. Nachteil ist nur, wenn man schon die Komboboxen gewählt hat und nachträglich eines der idenzifizierenden Felder ändert und dabei ein Duplikatsfehler erzeugt, werden die Komboboxen zurückgesetzt. Sollte aber eher ein Ausnahmefall sein, die Id-Felder nach den Komboboxen zu ändern.
